### PR TITLE
Fix date format string

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -56,7 +56,7 @@ exports.createPages = ({ boundActionCreators, graphql }) => {
           id
           timeToRead
           frontmatter {
-            date
+            date(formatString: "MMMM DD, YYYY")
             path
             tags
             title

--- a/public/index.html
+++ b/public/index.html
@@ -1,2 +1,2 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title data-react-helmet="true"></title></head><body><div id="___gatsby"></div><script src="/commons.js"></script></body></html>
+<html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title data-react-helmet="true"></title><script src="/socket.io/socket.io.js"></script></head><body><div id="___gatsby"></div><script src="/commons.js"></script></body></html>

--- a/src/html.js
+++ b/src/html.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Component from 'react';
 
-
 const BUILD_TIME = new Date().getTime();
 
 export default class HTML extends React.Component {

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -9,7 +9,7 @@ import '../css/index.scss';
 import '../css/basics.scss';
 
 export default function Tags({ data, pathContext }) {
-  const { post, tag, date } = pathContext;
+  const { post, tag } = pathContext;
   const { edges: posts } = data.allMarkdownRemark;
   if (tag) {
     return (
@@ -18,7 +18,7 @@ export default function Tags({ data, pathContext }) {
           <h1 className="serif italic tag-header">
             {post.length} post{post.length === 1 ? '' : 's'} tagged with “{tag}”
           </h1>
-          {post.map(({ id, frontmatter, date, excerpt }) => {
+          {post.map(({ id, frontmatter, excerpt }) => {
             return (
               <li key={id} className="link">
                 <GatsbyLink


### PR DESCRIPTION
Looks like we (weirdly?) have to configure that in gatsby-node.js, rather than at the root query level

Oh well, looks to be fixed now!